### PR TITLE
RT#84869 - avoid using user's aspell dictionary (~/.aspell.en.pws)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Test-Spelling
 
+        - for more consistent results avoid using the user's local aspell
+          dictionary (RT#84869, Karen Etheridge)
+
 0.18  2013-04-26
         - Work around Pod::Spell limitations (David Golden)
         - Improve case handling (David Golden)

--- a/lib/Test/Spelling.pm
+++ b/lib/Test/Spelling.pm
@@ -35,7 +35,7 @@ sub spellchecker_candidates {
 
     return (
         'spell', # for back-compat, this is the top candidate ...
-        'aspell list -l en', # ... but this should become first soon
+        'aspell list -l en -p /dev/null', # ... but this should become first soon
         'ispell -l',
         'hunspell -l',
     );


### PR DESCRIPTION
it looks like spell, ispell and hunspell don't use local user dictionaries by default, so only the aspell options need to be changed.
