### PR TITLE
Add a sorted wordcount to the bottom of all_pod_files_spelling_ok

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Test-Spelling
 
+        - Add a sorted list of most commonly misspelled words to the end of
+          all_pod_files_spelling_ok to aid stopword list creation and
+          bulk correction. (Kent Fredric)
+
 0.19  2013-05-05
         - for more consistent results avoid using the user's local aspell
           dictionary [rt.cpan.org #84869] (Karen Etheridge)


### PR DESCRIPTION
This makes nuking the most commonly misspelt words easier if you're
working on a large project with a lot of files, by helping you easily
see what needs to be deemed a "stopword" and what needs to be hit with
an edit pass.

This was an an apparent issue when I was adding a pod spelling check to dbix-class, which had 80 subtests worth of spelling failures which was hard to make sense of.

After this patch, it emits the following at the end:

```
# All wrong words: ActorRoles=1, Authorized=1, AutoCast=1, BelongsTo=1,
#    Bloggs=1, CachedKids=1, Centos=1, Compat=1, DBA=1, DELETEs=1, DEV=1,
#    Easysoft=1, Eg=1, FC=1, FileColumn=1, FirstSkip=1, FromForm=1, HRI=1,
#    INSERTs=1, Inflators=1, LimitXY=1, LiveObjectIndex=1, MRO=1,
#    ManyToMany=1, Microsft=1, Multicreate=1, MyApp=1, NULLs=1,
#    NoObjectIndex=1, Northwind=1, Optimizer=1, Overridability=1,
#    POSTGRESQL=1, Queryable=1, RDBMSes=1, RDMS=1, REPL=1, RESULTSET=1,
#    ReLoad=1, Reblessing=1, ResulSet=1, ResultSetColumn=1, Resultset=1,
#    Retrevial=1, RowNum=1, SQLT=1, SchemaVersions=1, Serializable=1,
#    Stringfy=1, Subquery=1, Subselects=1, Suported=1, TMTOWTDI=1,
#    TxnScopeGuard=1, UPDATEs=1, VARCHAR=1, WhereJoin=1, YYYY=1, albumid=1,
#    artifact=1, authorization=1, autodetected=1, autodetection=1,
#    autodetects=1, autoinc=1, autovalidation=1, blabla=1, bugreport=1,
#    caling=1, callframe=1, catalyze=1, cdbi=1, chocolateboy=1, columnname=1,
#    dbh=1, dclone=1, dcloned=1, dcloning=1, de=1, deallocating=1,
#    deferrable=1, dsn=1, explorative=1, failover=1, gR=1, generalized=1,
#    getter=1, gravatar=1, hundres=1, inflator=1, initialize=1, insertdb=1,
#    instantiation=1, introspectible=1, lifecycle=1, localize=1, logsystem=1,
#    materialized=1, mis=1, mysqld=1, nfreeze=1, nls=1, noindexed=1,
#    numification=1, onwards=1, optimized=1, optimizer=1, organize=1,
#    params=1, qw=1, randomizer=1, readbound=1, rebless=1, recognize=1,
#    reconnectable=1, reimplementation=1, ruleset=1, scalarref=1, se=1,
#    serializable=1, serialize=1, serialized=1, serializing=1, specialized=1,
#    sqlt=1, stacktrace=1, standardized=1, suboptimal=1, superset=1, sys=1,
#    sysdate=1, testdb=1, thusly=1, transactionally=1, txn=1, uncommited=1,
#    uninflated=1, uniqueidentifierstr=1, unixODBC=1, unserializable=1,
#    upto=1, utilize=1, versioning=1, webpages=1, xyz=1, AutoCommit=2,
#    BUILDARGS=2, DBs=2, DESC=2, EasySoft=2, FK=2, FilterColumn=2,
#    HashRefInflator=2, Kioku=2, LimitOffset=2, LinerNotes=2, ORMs=2,
#    PREFETCHING=2, Postgres=2, RHS=2, ResultSets=2, SELECTs=2, SkipFirst=2,
#    Subqueries=2, attr=2, autoincremented=2, autoincrementing=2,
#    balancers=2, callsites=2, colname=2, ddl=2, debugcb=2, fastpath=2,
#    freeform=2, incrementing=2, initialized=2, nextval=2, normalize=2,
#    nullable=2, overwritable=2, postgresql=2, prefetching=2, recognizes=2,
#    reconnection=2, resultsource=2, serialization=2, stringifiable=2,
#    syntaxes=2, uninserted=2, varchar=2, DBDs=3, Extensibility=3,
#    FetchFirst=3, InflateColumn=3, Informix=3, JOINs=3, PKs=3, Replicants=3,
#    RowNumberOver=3, TT=3, attrs=3, behaviors=3, natively=3, prefetches=3,
#    preversion=3, recognized=3, subquery=3, subref=3, subselects=3, unary=3,
#    uniqueidentifier=3, DSNs=4, GenericSubQ=4, RHEL=4, Replicant=4, cond=4,
#    debugfh=4, debugobj=4, overridable=4, reblessed=4, subqueries=4,
#    unversioned=4, ORM=5, ResultSources=5, callsite=5, normalizing=5,
#    classdata=6, eg=6, subselect=6, Firebird=7, prefetched=7, savepoints=8,
#    Balancer=9, DDL=9, LongReadLen=10, balancer=10, resultsets=11,
#    savepoint=13, sql=14, behavior=15, unicode=17, ODBC=23, replicants=42,
#    replicant=43, resultset=163
```

Which indicates `resultset` is either a good candidate for a stopword or a universal translation =).

Though "All wrong words" seems awkward and forceful, but I couldn't think of a better suggestion.
