### PR TITLE
Do not inherit from Exporter

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,7 @@ name       'Test-Spelling';
 all_from   'lib/Test/Spelling.pm';
 githubmeta;
 
+requires 'Exporter'   => '5.57';
 requires 'Pod::Spell' => '1.01';
 requires 'IPC::Run3'  => '0.044';
 test_requires 'Test::More' => '0.88';

--- a/lib/Test/Spelling.pm
+++ b/lib/Test/Spelling.pm
@@ -3,7 +3,7 @@ use 5.006;
 use strict;
 use warnings;
 
-use base 'Exporter';
+use Exporter 5.57 'import';
 use Pod::Spell;
 use Test::Builder;
 use Text::Wrap;


### PR DESCRIPTION
Instead, just import its 'import' method.
Requires Exporter 5.57, available in core since 5.8.3, or else on CPAN.
