### PR TITLE
Add unicode support

### DIFF
--- a/lib/Test/Spelling.pm
+++ b/lib/Test/Spelling.pm
@@ -101,9 +101,10 @@ sub invalid_words_in {
 
     my $document = '';
     open my $handle, '>', \$document;
+    open my $infile, '<:encoding(UTF-8)', $file;
 
     # save digested POD to the string $document
-    get_pod_parser()->parse_from_file($file, $handle);
+    get_pod_parser()->parse_from_filehandle($infile, $handle);
 
     my @words = _get_spellcheck_results($document);
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,6 +1,7 @@
 use Test::Tester;
 use Test::More;
 use Test::Spelling;
+use utf8;
 
 BEGIN {
     if (!has_working_spellchecker()) {
@@ -22,6 +23,13 @@ check_test(sub { pod_file_spelling_ok('t/corpus/bad-pod.pm', 'bad pod has no err
     ok   => 0,
     name => 'bad pod has no errors',
     diag => "Errors:\n    incorectly",
+});
+
+add_stopwords("ünıçöđé");
+
+check_test(sub { pod_file_spelling_ok('t/corpus/unicode-pod.pm', 'unicode pod has no errors') }, {
+    ok   => 1,
+    name => 'unicode pod has no errors',
 });
 
 done_testing;

--- a/t/corpus/unicode-pod.pm
+++ b/t/corpus/unicode-pod.pm
@@ -1,0 +1,16 @@
+package Unicode::Pod;
+use strict;
+use warnings;
+
+sub foo {}
+
+1;
+
+__END__
+
+=head1 NAME
+
+UTF8::Pod - POD with ünıçöđé
+
+=END
+


### PR DESCRIPTION
Class:Inspector had to remove "Test::Spelling" test completely, because
the test was failing due to a contributor whose name had a none a-zA-Z
character. Adding it as a stopword was not working either.

Pod::Spell documentation @ https://metacpan.org/pod/Pod::Spell#ENCODINGS
notes that default parse_from_file does not apply any encoding layer.
To get the encoding, we should replace it with parse_from_filehandle.

After this change, adding a stopword with non a-zA-Z character works
as expected. I also added a test to make sure this works.